### PR TITLE
[fix] tomato box TypeError, favicon 404 error / [feature] tomato box nickname focus and modify score storage method

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <!-- <script type="module" src="./src/pages/the-seventh-space/space.ts"></script> -->
     <script type="module" src="./src/pages/tomato-box/tomato-box.ts"></script>
     <!-- <script type="module" src="./src/pages/smash7-hit/smash.ts"></script> -->
+    <link rel="icon" href="/images/favicon.ico" />
   </head>
   <body>
     <div class="app">

--- a/src/pages/tomato-box/tomato-box.html
+++ b/src/pages/tomato-box/tomato-box.html
@@ -6,9 +6,6 @@
     <title>Tomato Box</title>
     <script type="module" src="./tomato-box.ts"></script>
     <link rel="stylesheet" href="./tomato-box.css" />
-    <link rel="preload" as="font" href="/fonts/DungGeunMo.woff" crossorigin="anonymous" />
-    <link rel="preload" as="font" href="/fonts/DungGeunMo.woff2" crossorigin="anonymous" />
-    <link rel="icon" href="../../../public/images/favicon.ico" />
   </head>
   <body>
     <div class="bg">

--- a/src/pages/tomato-box/tomato-box.ts
+++ b/src/pages/tomato-box/tomato-box.ts
@@ -3,9 +3,6 @@ import './tomato-box.css';
 import tomatoImg from '../../assets/images/tomato-img/tomato-empty.png';
 import tomatoSelectedSrc from '../../assets/images/tomato-img/select-tomato.png';
 
-// 실행
-document.addEventListener('DOMContentLoaded', main);
-
 // 전역 변수
 const trophyBtn = document.querySelector('.trophy');
 const bestScore = document.querySelector('.bestscore') as HTMLElement;
@@ -64,12 +61,29 @@ const localKey = 'tomatobox_Score';
 
 let bgm: HTMLAudioElement;
 
+document.addEventListener('DOMContentLoaded', () => {
+  tomatoIntro();
+});
+
 // 메인, 게임 실행 함수
 function main() {
-  canvas = document.querySelector('canvas') as HTMLCanvasElement;
-  ctx = canvas.getContext('2d')!;
+  const canvasEl = document.querySelector('canvas');
 
-  tomatoIntro();
+  if (!canvasEl) {
+    console.error('Canvas not found');
+    return;
+  }
+
+  canvas = canvasEl as HTMLCanvasElement;
+
+  const maybeCtx = canvas.getContext('2d');
+  if (!maybeCtx) {
+    console.error('getContext failed');
+    return;
+  }
+
+  ctx = maybeCtx;
+
   playGrid();
   events();
   animateTomatoes();
@@ -92,6 +106,10 @@ function tomatoIntro() {
     intro?.classList.remove('show');
     play?.classList.remove('hide');
     play?.classList.add('show');
+
+    setTimeout(() => {
+      main();
+    }, 50);
 
     playBgm('/sounds/tomato-bgm.wav');
     playIcon('/sounds/pointer.wav');
@@ -144,7 +162,15 @@ function setNumStyle() {
 
 // 토마토, 숫자 그리기
 function playGrid() {
-  Promise.all([document.fonts.ready, new Promise(resolve => (tomatoImage.onload = resolve))]).then(() => {
+  const tomatoReady = new Promise<void>(resolve => {
+    if (tomatoImage.complete) {
+      resolve();
+    } else {
+      tomatoImage.onload = () => resolve();
+    }
+  });
+
+  Promise.all([document.fonts.ready, tomatoReady]).then(() => {
     setNumStyle();
 
     for (let row = 0; row < rows; row++) {
@@ -401,6 +427,7 @@ function events() {
       return;
     }
     playIcon('/sounds/pointer.wav');
+
     const name = nicknameInput.value.trim().toUpperCase();
     const score = scoreNum;
 

--- a/src/pages/tomato-box/tomato-box.ts
+++ b/src/pages/tomato-box/tomato-box.ts
@@ -387,6 +387,7 @@ function events() {
     if (!isVisible) {
       saveScore.classList.remove('hide');
       saveScore.classList.add('show');
+      nicknameInput.focus();
     } else {
       saveScore.classList.remove('show');
       saveScore.classList.add('hide');
@@ -433,8 +434,9 @@ function events() {
 
     const newEntry: ScoreArray = { name, score };
     const stored = localStorage.getItem(localKey);
-    const scoreList: ScoreArray[] = stored ? JSON.parse(stored) : [];
+    let scoreList: ScoreArray[] = stored ? JSON.parse(stored) : [];
 
+    scoreList = scoreList.filter(entry => entry.name !== name);
     scoreList.unshift(newEntry);
     scoreList.sort((a, b) => b.score - a.score);
     localStorage.setItem(localKey, JSON.stringify(scoreList));


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
- preview시  발생하는 canvas null 타입 에러 문제 해결을 위해 타입 가드 설정
    - DOMContentLoaded에 main() 대신 tomatoIntro() 전달
        - start 버튼 클릭 시, main 실행되도록 수정
        - tomato 그리기 방식 Promise 수정
- favicon 404 에러 수정 -> index.html에 추가
- 중복 닉네임이 저장될 경우, 최신순으로 교체하도록 수정
- 닉네임 입력 받는 창 열릴 시, input 포커스 받도록 설정

## 이슈

resolves #68 
resolves #70 
